### PR TITLE
Ignoring parentheses in section titles for TableOfContents module

### DIFF
--- a/MarkdownPP/Modules/TableOfContents.py
+++ b/MarkdownPP/Modules/TableOfContents.py
@@ -101,7 +101,7 @@ class TableOfContents(Module):
 
 			(depth, title) = headers[linenum]
 			depth += depthoffset
-			short = re.sub("([\s,-]+)", "", title).lower()
+			short = re.sub("([\s,-,\(,\)]+)", "", title).lower()
 
 			while depth > lastdepth:
 				stack.append(headernum)


### PR DESCRIPTION
Including parentheses in link anchors can result in improper Markdown syntax, so I modified TableOfContents to ignore parentheses in section titles.
