### PR TITLE
Support for headings with links in them

### DIFF
--- a/MarkdownPP/Modules/TableOfContents.py
+++ b/MarkdownPP/Modules/TableOfContents.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010 John Reese
 # Licensed under the MIT license
 
-import re, sys
+import re
 
 from MarkdownPP.Module import Module
 from MarkdownPP.Transform import Transform
@@ -26,7 +26,6 @@ class TableOfContents(Module):
 		return title
 
 	def transform(self, data):
-		print data
 		transforms = []
 
 		lowestdepth = 10
@@ -142,6 +141,7 @@ class TableOfContents(Module):
 				section = ".".join([str(x) for x in stack]) + ".%d\\. " % headernum
 
 			tocdata += "%s [%s](#%s)  \n" % (section, TableOfContents.clean_title(title), short)
+			
 			transforms.append(Transform(linenum, "swap", data[linenum].replace(title, section + title)))
 			transforms.append(Transform(linenum, "prepend", "<a name=\"%s\"></a>\n\n" % short))
 


### PR DESCRIPTION
markdown-pp used to produce something like this when it encountered headings with links:

```
3.3\.  [[macvim](http://code.google.com/p/macvim/)](#[macvim]http://code.google.com/p/macvim/)  
<a name="[macvim]http://code.google.com/p/macvim/"></a>
## [macvim](http://code.google.com/p/macvim/)
```

Now, you'll see this:

```
3.3\.  [macvim](#macvim)  
<a name="macvim"></a>
## [macvim](http://code.google.com/p/macvim/)
```
