### PR TITLE
Change CLI - allow specific modules to be excluded

### DIFF
--- a/markdown-pp.py
+++ b/markdown-pp.py
@@ -5,19 +5,36 @@
 
 import sys
 import MarkdownPP
+import argparse
 
-if len(sys.argv) > 2:
-	mdpp = open(sys.argv[1], "r")
-	md = open(sys.argv[2], "w")
+description = "Preprocessor for Markdown files." \
 
-elif len(sys.argv) > 1:
-	mdpp = open(sys.argv[1], "r")
+parser = argparse.ArgumentParser(description=description)
+parser.add_argument('FILENAME', help='Input file name')
+parser.add_argument("-o", "--output", help="Output file name." \
+    + " If no output file is specified, writes output to stdout.")
+parser.add_argument('-e', '--exclude',\
+ help='List of modules to exclude, separated by commas. ' \
+ +'Available modules: ' + ", ".join(MarkdownPP.modules.keys()))
+args = parser.parse_args()
+
+
+mdpp = open(args.FILENAME, "r")
+if args.output:
+	md = open(args.output, "w")
+else:
 	md = sys.stdout
 
-else:
-	sys.exit(1)
-	
-MarkdownPP.MarkdownPP(input=mdpp, output=md, modules=MarkdownPP.modules.keys())
+modules = MarkdownPP.modules.keys();
+
+if args.exclude:
+	for module in args.exclude.split(','):
+		if module in modules:
+			modules.remove(module)
+		else:
+			print "Cannot exclude ", module, " - no such module"
+ 
+MarkdownPP.MarkdownPP(input=mdpp, output=md, modules=modules)
 
 mdpp.close()
 md.close()

--- a/readme.md
+++ b/readme.md
@@ -48,14 +48,20 @@ Python script that acts as a simple command line interface to the module,
 Assuming you have a file named `foo.mdpp`, you can generate the preprocessed
 file `foo.md` by running the following command:
 
-    $ path/to/markdown-pp.py foo.mdpp foo.md
+    $ path/to/markdown-pp.py foo.mdpp -o foo.md
 
-Because the current CLI script is very simple, it just automatically selects
-all available modules for the preprocessor to use.  I will eventually get to
-the point of adding command parameters and switches to select modules.  In the
-mean time, if you only want to use a subset of modules, you can either modify
-`markdown-pp.py` directly, or duplicate its usage of the core module with your
-own list of preferred modules.
+If you do not specify an output file name, the results will be printed to 
+stdout, enabling them to be piped to another command.
+
+By default, all available modules are enabled. You can specify a list of
+modules to exclude:
+
+    $ path/to/markdown-pp.py foo.mdpp -o foo.md -e latexrender,youtubembed
+
+To see usage instructions, including a list of enabled modules, supply the
+-h or --help arguments:
+
+    $ path/to/markdown-pp.py --help
 
 <a name="modules"></a>
 

--- a/readme.mdpp
+++ b/readme.mdpp
@@ -37,14 +37,20 @@ Python script that acts as a simple command line interface to the module,
 Assuming you have a file named `foo.mdpp`, you can generate the preprocessed
 file `foo.md` by running the following command:
 
-    $ path/to/markdown-pp.py foo.mdpp foo.md
+    $ path/to/markdown-pp.py foo.mdpp -o foo.md
 
-Because the current CLI script is very simple, it just automatically selects
-all available modules for the preprocessor to use.  I will eventually get to
-the point of adding command parameters and switches to select modules.  In the
-mean time, if you only want to use a subset of modules, you can either modify
-`markdown-pp.py` directly, or duplicate its usage of the core module with your
-own list of preferred modules.
+If you do not specify an output file name, the results will be printed to 
+stdout, enabling them to be piped to another command.
+
+By default, all available modules are enabled. You can specify a list of
+modules to exclude:
+
+    $ path/to/markdown-pp.py foo.mdpp -o foo.md -e latexrender,youtubembed
+
+To see usage instructions, including a list of enabled modules, supply the
+-h or --help arguments:
+
+    $ path/to/markdown-pp.py --help
 
 Modules
 --------

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,7 @@ setup(name = "MarkdownPP",
       license='MIT License',
       scripts = ['markdown-pp.py'],
       packages = ['MarkdownPP', 'MarkdownPP/Modules'],
+      install_requires=[
+          'argparse',
+      ],
       )


### PR DESCRIPTION
Rather than handling sys.argv directly, use argparse. Add option allowing users to specify a list of modules to exclude.
