### PR TITLE
Print error message when a non-existent file is included.

### DIFF
--- a/MarkdownPP/Modules/Include.py
+++ b/MarkdownPP/Modules/Include.py
@@ -67,7 +67,7 @@ class Include(Module):
 
             return data
 
-        except (FileNotFoundError, IOError) as exc:
+        except (IOError, OSError) as exc:
             print(exc)
 
         return []

--- a/MarkdownPP/Modules/Include.py
+++ b/MarkdownPP/Modules/Include.py
@@ -50,7 +50,7 @@ class Include(Module):
         if not path.isabs(filename):
             filename = path.join(pwd, filename)
 
-        if path.isfile(filename):
+        try:
             f = open(filename, "r")
             data = f.readlines()
             f.close()
@@ -66,5 +66,8 @@ class Include(Module):
                 linenum += 1
 
             return data
+
+        except FileNotFoundError as exc:
+            print(exc)
 
         return []

--- a/MarkdownPP/Modules/Include.py
+++ b/MarkdownPP/Modules/Include.py
@@ -67,7 +67,7 @@ class Include(Module):
 
             return data
 
-        except FileNotFoundError as exc:
+        except (FileNotFoundError, IOError) as exc:
             print(exc)
 
         return []


### PR DESCRIPTION
Addresses [issue 14](https://github.com/jreese/markdown-pp/issues/14). Output is same as before: if a non existent file is included, the `!INCLUDE` directive is erased and a blank line is left instead. The only change is now markdown-pp prints an error to stdout.
