### PR TITLE
Test

### DIFF
--- a/MarkdownPP/MarkdownPP.py
+++ b/MarkdownPP/MarkdownPP.py
@@ -19,9 +19,7 @@ class MarkdownPP:
     def __init__(self, input=None, output=None, modules=None):
         pp = Processor()
 
-        map(str.lower, modules)
-
-        for name in modules:
+        for name in [m.lower() for m in modules]:
             if name in Modules.modules:
                 module = Modules.modules[name]()
                 pp.register(module)

--- a/MarkdownPP/Modules/IncludeURL.py
+++ b/MarkdownPP/Modules/IncludeURL.py
@@ -39,7 +39,7 @@ class IncludeURL(Include):
             url = match.group(1)
 
         parsed_url = urlparse(url)
-        if not parsed_url.netloc:
+        if not parsed_url.netloc and not parsed_url.path:
             return []
 
         binary_data = urlopen(url).readlines()

--- a/makefile
+++ b/makefile
@@ -16,6 +16,7 @@ lint:
 test: lint
 	python bin/markdown-pp readme.mdpp -o readme.test && diff -u readme.md readme.test
 	rm -f readme.test
+	cd test/ && python test.py
 
 clean:
 	rm -rf build dist README MANIFEST MarkdownPP.egg-info

--- a/test/test.py
+++ b/test/test.py
@@ -16,34 +16,35 @@ from io import StringIO
 class MarkdownPPTests(unittest.TestCase):
 
     def test_include(self):
-        output = StringIO()
+        input = StringIO('foobar\n!INCLUDE "test_include.md"\n')
+        result = 'foobar\nThis is a test.\n'
 
-        MarkdownPP(input=StringIO('foobar\n!INCLUDE "test_include.md"\n'),
-                   modules=['include'],
-                   output=output)
+        output = StringIO()
+        MarkdownPP(input=input, modules=['include'], output=output)
 
         output.seek(0)
-        self.assertEqual(output.read(), 'foobar\nThis is a test.\n')
+        self.assertEqual(output.read(), result)
 
     def test_include_url(self):
-        output = StringIO()
         path = os.path.join(os.getcwd(), "test_include.md")
+        input = StringIO('foobar\n!INCLUDEURL "file://{}"\n'.format(path))
+        result = 'foobar\nThis is a test.\n'
 
-        MarkdownPP(input=StringIO('foobar\n!INCLUDEURL "file://{}"\n'.format(path)),
-                   modules=['includeurl'],
-                   output=output)
+        output = StringIO()
+        MarkdownPP(input=input, modules=['includeurl'], output=output)
 
         output.seek(0)
-        self.assertEqual(output.read(), 'foobar\nThis is a test.\n')
+        self.assertEqual(output.read(), result)
 
     def test_youtube(self):
+        input = StringIO('foobar\n!VIDEO "http://www.youtube.com/embed/7aEYoP5-duY"\n')
+        result = 'foobar\n[![Link to Youtube video](images/youtube/7aEYoP5-duY.png)](http://www.youtube.com/watch?v=7aEYoP5-duY)\n'
+
         output = StringIO()
-        MarkdownPP(input=StringIO('foobar\n!VIDEO "http://www.youtube.com/embed/7aEYoP5-duY"\n'),
-                   modules=['youtubeembed'],
-                   output=output)
+        MarkdownPP(input=input, modules=['youtubeembed'], output=output)
 
         output.seek(0)
-        self.assertEqual(output.read(), 'foobar\n[![Link to Youtube video](images/youtube/7aEYoP5-duY.png)](http://www.youtube.com/watch?v=7aEYoP5-duY)\n')
+        self.assertEqual(output.read(), result)
 
     def test_toc(self):
         input = StringIO('\n# Document Title\n\n'

--- a/test/test.py
+++ b/test/test.py
@@ -6,6 +6,10 @@ Unit testing for MarkdownPP.
 
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 import os
 import re

--- a/test/test.py
+++ b/test/test.py
@@ -15,7 +15,12 @@ import os
 import re
 from MarkdownPP import MarkdownPP
 from MarkdownPP import modules as Modules
-from io import StringIO
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 
 
 class MarkdownPPTests(unittest.TestCase):

--- a/test/test.py
+++ b/test/test.py
@@ -24,6 +24,17 @@ class MarkdownPPTests(unittest.TestCase):
         output.seek(0)
         self.assertEqual(output.read(), 'foobar\nThis is a test.\n')
 
+    def test_include_url(self):
+        output = StringIO()
+        path = os.path.join(os.getcwd(), "test_include.md")
+
+        MarkdownPP(input=StringIO('foobar\n!INCLUDEURL "file://{}"\n'.format(path)),
+                   modules=['includeurl'],
+                   output=output)
+
+        output.seek(0)
+        self.assertEqual(output.read(), 'foobar\nThis is a test.\n')
+
 
 
 if __name__ == '__main__':

--- a/test/test.py
+++ b/test/test.py
@@ -8,6 +8,7 @@ Unit testing for MarkdownPP.
 
 import unittest
 import os
+import re
 from MarkdownPP import MarkdownPP
 from io import StringIO
 
@@ -43,6 +44,60 @@ class MarkdownPPTests(unittest.TestCase):
 
         output.seek(0)
         self.assertEqual(output.read(), 'foobar\n[![Link to Youtube video](images/youtube/7aEYoP5-duY.png)](http://www.youtube.com/watch?v=7aEYoP5-duY)\n')
+
+    def test_toc(self):
+        input = StringIO('\n# Document Title\n\n'
+                         '!TOC\n\n'
+                         '## Header 1\n'
+                         '### Header 1.a\n'
+                         '## Header 2\n')
+
+        result = """
+        # Document Title
+
+        1\.  [Header 1](#header1)
+        1.1\.  [Header 1.a](#header1.a)
+        2\.  [Header 2](#header2)
+
+        <a name="header1"></a>
+
+        ## 1\. Header 1
+        <a name="header1.a"></a>
+
+        ### 1.1\. Header 1.a
+        <a name="header2"></a>
+
+        ## 2\. Header 2"""
+
+        output = StringIO()
+        MarkdownPP(input=input, modules=['tableofcontents'], output=output)
+
+        output.seek(0)
+        self.assertEqual([l.strip() for l in output.readlines()],
+                         [l.strip() for l in result.split('\n')])
+
+    def test_reference(self):
+        input = StringIO('\n!REF\n\n[github]: http://github.com "GitHub"')
+        result = '\n*\t[GitHub][github]\n\n[github]: http://github.com "GitHub"'
+
+        output = StringIO()
+        MarkdownPP(input=input, modules=['reference'], output=output)
+
+        output.seek(0)
+        self.assertEqual(output.read(), result)
+
+    def test_latexrender(self):
+        input = StringIO('$\displaystyle 1 + 1 = 2 $')
+        result_re = r'!\[\\displaystyle 1 \+ 1 = 2 \]\(http:\/\/quicklatex\.com\/.*\.png "\\displaystyle 1 \+ 1 = 2 "\)'
+
+        output = StringIO()
+        MarkdownPP(input=input, modules=['latexrender'], output=output)
+
+        output.seek(0)
+        output_str = output.read().strip()
+        match = re.match(result_re, output_str)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.span(), (0, len(output_str)))
 
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -22,7 +22,6 @@ except ImportError:
     from io import StringIO
 
 
-
 class MarkdownPPTests(unittest.TestCase):
 
     def test_include(self):

--- a/test/test.py
+++ b/test/test.py
@@ -35,6 +35,15 @@ class MarkdownPPTests(unittest.TestCase):
         output.seek(0)
         self.assertEqual(output.read(), 'foobar\nThis is a test.\n')
 
+    def test_youtube(self):
+        output = StringIO()
+        MarkdownPP(input=StringIO('foobar\n!VIDEO "http://www.youtube.com/embed/7aEYoP5-duY"\n'),
+                   modules=['youtubeembed'],
+                   output=output)
+
+        output.seek(0)
+        self.assertEqual(output.read(), 'foobar\n[![Link to Youtube video](images/youtube/7aEYoP5-duY.png)](http://www.youtube.com/watch?v=7aEYoP5-duY)\n')
+
 
 
 if __name__ == '__main__':

--- a/test/test.py
+++ b/test/test.py
@@ -10,6 +10,7 @@ import unittest
 import os
 import re
 from MarkdownPP import MarkdownPP
+from MarkdownPP import modules as Modules
 from io import StringIO
 
 
@@ -99,6 +100,19 @@ class MarkdownPPTests(unittest.TestCase):
         match = re.match(result_re, output_str)
         self.assertIsNotNone(match)
         self.assertEqual(match.span(), (0, len(output_str)))
+
+    def test_file(self):
+        with open('../readme.mdpp', 'r') as mdpp, open('../readme.md', 'r') as md:
+            input = mdpp
+            result = md.read()
+
+            output = StringIO()
+            modules = list(Modules.keys())
+            MarkdownPP(input=input, modules=modules, output=output)
+
+        output.seek(0)
+        self.assertEqual(output.read(), result)
+
 
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,30 @@
+"""
+test.py
+-------
+
+Unit testing for MarkdownPP.
+
+"""
+
+import unittest
+import os
+from MarkdownPP import MarkdownPP
+from io import StringIO
+
+
+class MarkdownPPTests(unittest.TestCase):
+
+    def test_include(self):
+        output = StringIO()
+
+        MarkdownPP(input=StringIO('foobar\n!INCLUDE "test_include.md"\n'),
+                   modules=['include'],
+                   output=output)
+
+        output.seek(0)
+        self.assertEqual(output.read(), 'foobar\nThis is a test.\n')
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -38,8 +38,11 @@ class MarkdownPPTests(unittest.TestCase):
         self.assertEqual(output.read(), result)
 
     def test_youtube(self):
-        input = StringIO('foobar\n!VIDEO "http://www.youtube.com/embed/7aEYoP5-duY"\n')
-        result = 'foobar\n[![Link to Youtube video](images/youtube/7aEYoP5-duY.png)](http://www.youtube.com/watch?v=7aEYoP5-duY)\n'
+        input = StringIO('foobar\n!VIDEO '
+                         '"http://www.youtube.com/embed/7aEYoP5-duY"\n')
+        result = ('foobar\n'
+                  '[![Link to Youtube video](images/youtube/7aEYoP5-duY.png)]'
+                  '(http://www.youtube.com/watch?v=7aEYoP5-duY)\n')
 
         output = StringIO()
         MarkdownPP(input=input, modules=['youtubeembed'], output=output)
@@ -80,7 +83,8 @@ class MarkdownPPTests(unittest.TestCase):
 
     def test_reference(self):
         input = StringIO('\n!REF\n\n[github]: http://github.com "GitHub"')
-        result = '\n*\t[GitHub][github]\n\n[github]: http://github.com "GitHub"'
+        result = ('\n*\t[GitHub][github]\n\n[github]: '
+                  'http://github.com "GitHub"')
 
         output = StringIO()
         MarkdownPP(input=input, modules=['reference'], output=output)
@@ -90,7 +94,9 @@ class MarkdownPPTests(unittest.TestCase):
 
     def test_latexrender(self):
         input = StringIO('$\displaystyle 1 + 1 = 2 $')
-        result_re = r'!\[\\displaystyle 1 \+ 1 = 2 \]\(http:\/\/quicklatex\.com\/.*\.png "\\displaystyle 1 \+ 1 = 2 "\)'
+        result_re = (r'!\[\\displaystyle 1 \+ 1 = 2 \]'
+                     r'\(http:\/\/quicklatex\.com\/.*\.png "'
+                     r'\\displaystyle 1 \+ 1 = 2 "\)')
 
         output = StringIO()
         MarkdownPP(input=input, modules=['latexrender'], output=output)
@@ -102,9 +108,11 @@ class MarkdownPPTests(unittest.TestCase):
         self.assertEqual(match.span(), (0, len(output_str)))
 
     def test_file(self):
-        with open('../readme.mdpp', 'r') as mdpp, open('../readme.md', 'r') as md:
-            input = mdpp
+        with open('../readme.md', 'r') as md:
             result = md.read()
+
+        with open('../readme.mdpp', 'r') as mdpp:
+            input = mdpp
 
             output = StringIO()
             modules = list(Modules.keys())

--- a/test/test.py
+++ b/test/test.py
@@ -114,7 +114,5 @@ class MarkdownPPTests(unittest.TestCase):
         self.assertEqual(output.read(), result)
 
 
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_include.md
+++ b/test/test_include.md
@@ -1,0 +1,1 @@
+This is a test.


### PR DESCRIPTION
Before working on another PR, I wanted to implement some basic tests.

* `test/test.py` implements one test for each module, plus one for the `readme.mdpp` file, using the `unittest` package.
* `test/test_include.py` is a dummy file used in tests.
* The change in `Modules/IncludeURL.py` was necessary in order to make the `!INCLUDEURL` directive accept uris of the form `file://path_to_local_file` (used in `test.test_include_url`). Of course, including local files is not the point of IncludeURL, but it seemed like a small enough change to make the test work. Furthermore, I couldn't think of a good static url that would always reliably return the same text, so I settled for including a local file.
