### PR TITLE
Put argument parsing and command execution inside `if __name__ == '__main__'` clause

### DIFF
--- a/bin/markdown-pp
+++ b/bin/markdown-pp
@@ -16,12 +16,14 @@ import time
 from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 
+
 # Terminal output ANSI color codes
 class colors:
-    BLUE   = '\033[36;49;22m'
-    MAGB   = '\033[35;49;1m'
-    GREEN  = '\033[32;49;22m'
+    BLUE = '\033[36;49;22m'
+    MAGB = '\033[35;49;1m'
+    GREEN = '\033[32;49;22m'
     NORMAL = '\033[0m'
+
 
 # Custom event handler for watchdog observer
 class MarkdownPPFileEventHandler(PatternMatchingEventHandler):
@@ -38,10 +40,10 @@ class MarkdownPPFileEventHandler(PatternMatchingEventHandler):
 
         # Logs time and file changed (with colors!)
         print(time.strftime("%c") + ":",
-            colors.MAGB + event.src_path, 
-            colors.GREEN + event.event_type,
-            "and processed with MarkdownPP",
-            colors.NORMAL)
+              colors.MAGB + event.src_path,
+              colors.GREEN + event.event_type,
+              "and processed with MarkdownPP",
+              colors.NORMAL)
 
     def on_modified(self, event):
         self.process(event)
@@ -50,61 +52,64 @@ class MarkdownPPFileEventHandler(PatternMatchingEventHandler):
         self.process(event)
 
 
-description = "Preprocessor for Markdown files."
+if __name__ == '__main__':
+    # setup command line arguments
+    parser = argparse.ArgumentParser(description='Preprocessor for Markdown'
+                                     ' files.')
 
-parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('FILENAME', help='Input file name (or directory if '
+                        'watching)')
 
-# Argument for watching directory and subdirectory to process .mdpp files
-parser.add_argument('-w', '--watch', action='store_true', help='Watch current '
-                    'directory and subdirectories for changing .mdpp files and '
-                    'process in local directory. File output name is same as '
-                    'file input name.')
-parser.add_argument('FILENAME', help='Input file name (or directory if watching)')
-parser.add_argument('-o', '--output', help='Output file name. '
-                    'If no output file is specified, writes output to stdout.')
-parser.add_argument('-e', '--exclude',
-                    help='List of modules to exclude, separated by commas. '
-                    'Available modules: ' +
-                    ', '.join(MarkdownPP.modules.keys()))
-args = parser.parse_args()
+    # Argument for watching directory and subdirectory to process .mdpp files
+    parser.add_argument('-w', '--watch', action='store_true', help='Watch '
+                        'current directory and subdirectories for changing '
+                        '.mdpp files and process in local directory. File '
+                        'output name is same as file input name.')
 
-# If watch flag is on, watch dirs instead of processing individual file
-if args.watch:
-    # Get full directory path to print
-    p = os.path.abspath(args.FILENAME)
-    print("Watching: " + p + " (and subdirectories)")
+    parser.add_argument('-o', '--output', help='Output file name. If no '
+                        'output file is specified, writes output to stdout.')
+    parser.add_argument('-e', '--exclude', help='List of modules to '
+                        'exclude, separated by commas. Available modules: '
+                        ', '.join(MarkdownPP.modules.keys()))
+    args = parser.parse_args()
 
-    # Custom watchdog event handler specific for .mdpp files
-    event_handler = MarkdownPPFileEventHandler()
-    observer = Observer()
-    # pass event handler, directory, and flag to recurse subdirectories
-    observer.schedule(event_handler, args.FILENAME, recursive=True)
-    observer.start()
+    # If watch flag is on, watch dirs instead of processing individual file
+    if args.watch:
+        # Get full directory path to print
+        p = os.path.abspath(args.FILENAME)
+        print("Watching: " + p + " (and subdirectories)")
 
-    try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        observer.stop()
-    observer.join()
+        # Custom watchdog event handler specific for .mdpp files
+        event_handler = MarkdownPPFileEventHandler()
+        observer = Observer()
+        # pass event handler, directory, and flag to recurse subdirectories
+        observer.schedule(event_handler, args.FILENAME, recursive=True)
+        observer.start()
 
-else:
-    mdpp = open(args.FILENAME, 'r')
-    if args.output:
-        md = open(args.output, 'w')
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            observer.stop()
+        observer.join()
+
     else:
-        md = sys.stdout
+        mdpp = open(args.FILENAME, 'r')
+        if args.output:
+            md = open(args.output, 'w')
+        else:
+            md = sys.stdout
 
-    modules = MarkdownPP.modules.keys()
+        modules = MarkdownPP.modules.keys()
 
-    if args.exclude:
-        for module in args.exclude.split(','):
-            if module in modules:
-                modules.remove(module)
-            else:
-                print('Cannot exclude ', module, ' - no such module')
+        if args.exclude:
+            for module in args.exclude.split(','):
+                if module in modules:
+                    modules.remove(module)
+                else:
+                    print('Cannot exclude ', module, ' - no such module')
 
-    MarkdownPP.MarkdownPP(input=mdpp, output=md, modules=modules)
+        MarkdownPP.MarkdownPP(input=mdpp, output=md, modules=modules)
 
-    mdpp.close()
-    md.close()
+        mdpp.close()
+        md.close()

--- a/test/datafiles/test_script.mdpp
+++ b/test/datafiles/test_script.mdpp
@@ -1,0 +1,31 @@
+<!--The output file does not have the .md extension on purpose.  If it did,
+    running markdown-pp over the input file would possibly overwrite it.-->
+
+!TOC
+
+
+# Test include
+!INCLUDE "datafiles/test_include.md"
+
+
+# Test include url
+!INCLUDEURL "file:///home/leo/code/markdown-pp/test/datafiles/test_include.md"
+
+
+# Test youtube embed
+!VIDEO "http://www.youtube.com/embed/7aEYoP5-duY"\n"
+
+
+# Test shift 1
+!INCLUDE "datafiles/test_shift.mdpp", 1
+
+
+# Test shift 2
+
+!INCLUDE "datafiles/test_shift.mdpp", 2
+
+
+# Test reference list
+[github]: http://github.com "GitHub"
+
+!REF

--- a/test/datafiles/test_script.mdpp
+++ b/test/datafiles/test_script.mdpp
@@ -9,7 +9,7 @@
 
 
 # Test include url
-!INCLUDEURL "file:///home/leo/code/markdown-pp/test/datafiles/test_include.md"
+!INCLUDEURL "file:datafiles/test_include.md"
 
 
 # Test youtube embed

--- a/test/datafiles/test_script.txt
+++ b/test/datafiles/test_script.txt
@@ -1,0 +1,91 @@
+<!--The output file does not have the .md extension on purpose.  If it did,
+    running markdown-pp over the input file would possibly overwrite it.-->
+
+1\.  [Test include](#testinclude)  
+2\.  [Test include url](#testincludeurl)  
+3\.  [Test youtube embed](#testyoutubeembed)  
+4\.  [Test shift 1](#testshift1)  
+4.1\.  [Title](#title)  
+4.1.1\.  [Subtitle](#subtitle)  
+4.2\.  [Title](#title-1)  
+4.2.1\.  [Subtitle](#subtitle-1)  
+4.2.1.1\.  [Subsubtitle](#subsubtitle)  
+5\.  [Test shift 2](#testshift2)  
+5.0.1\.  [Title](#title-2)  
+5.0.1.1\.  [Subtitle](#subtitle-2)  
+5.0.2\.  [Title](#title-3)  
+5.0.2.1\.  [Subtitle](#subtitle-3)  
+5.0.2.1.1\.  [Subsubtitle](#subsubtitle-1)  
+6\.  [Test reference list](#testreferencelist)  
+
+
+<a name="testinclude"></a>
+
+# 1\. Test include
+This is a test.
+
+
+<a name="testincludeurl"></a>
+
+# 2\. Test include url
+This is a test.
+
+
+<a name="testyoutubeembed"></a>
+
+# 3\. Test youtube embed
+[![Link to Youtube video](images/youtube/7aEYoP5-duY.png)](http://www.youtube.com/watch?v=7aEYoP5-duY)
+
+
+<a name="testshift1"></a>
+
+# 4\. Test shift 1
+<a name="title"></a>
+
+4.1\. Title
+-----
+
+<a name="subtitle"></a>
+
+### 4.1.1\. Subtitle
+
+<a name="title-1"></a>
+
+## 4.2\. Title
+<a name="subtitle-1"></a>
+
+### 4.2.1\. Subtitle
+<a name="subsubtitle"></a>
+
+#### 4.2.1.1\. Subsubtitle
+
+
+<a name="testshift2"></a>
+
+# 5\. Test shift 2
+
+<a name="title-2"></a>
+
+### 5.0.1\. Title
+
+<a name="subtitle-2"></a>
+
+#### 5.0.1.1\. Subtitle
+
+<a name="title-3"></a>
+
+### 5.0.2\. Title
+<a name="subtitle-3"></a>
+
+#### 5.0.2.1\. Subtitle
+<a name="subsubtitle-1"></a>
+
+##### 5.0.2.1.1\. Subsubtitle
+
+
+<a name="testreferencelist"></a>
+
+# 6\. Test reference list
+[github]: http://github.com "GitHub"
+
+*	[GitHub][github]

--- a/test/test.py
+++ b/test/test.py
@@ -13,6 +13,7 @@ from __future__ import unicode_literals
 import unittest
 import os
 import re
+import subprocess
 from MarkdownPP import MarkdownPP
 from MarkdownPP import modules as Modules
 from tempfile import NamedTemporaryFile
@@ -161,6 +162,18 @@ class MarkdownPPTests(unittest.TestCase):
 
         self.assertEqual(output1.read(), output2.read())
         os.remove(name)
+
+    def test_script(self):
+        # test the script without arguments
+        with NamedTemporaryFile(delete=False) as temp_outfile:
+            subprocess.run(['markdown-pp', 'datafiles/test_script.mdpp', '-o',
+                            temp_outfile.name])
+
+            with open('datafiles/test_script.txt', 'r') as target_outfile:
+                target_out = target_outfile.read()
+
+            temp_outfile.seek(0)
+            self.assertEqual(target_out, temp_outfile.read().decode('utf-8'))
 
 
 if __name__ == '__main__':

--- a/test/test.py
+++ b/test/test.py
@@ -37,8 +37,8 @@ class MarkdownPPTests(unittest.TestCase):
         self.assertEqual(output.read(), result)
 
     def test_include_url(self):
-        path = os.path.join(os.getcwd(), "datafiles/test_include.md")
-        input = StringIO('foobar\n!INCLUDEURL "file://{}"\n'.format(path))
+        input = StringIO('foobar\n!INCLUDEURL '
+                         '"file:datafiles/test_include.md"\n')
         result = 'foobar\nThis is a test.\n'
 
         output = StringIO()
@@ -166,7 +166,7 @@ class MarkdownPPTests(unittest.TestCase):
     def test_script(self):
         # test the script without arguments
         with NamedTemporaryFile(delete=False) as temp_outfile:
-            subprocess.run(['markdown-pp', 'datafiles/test_script.mdpp', '-o',
+            subprocess.call(['markdown-pp', 'datafiles/test_script.mdpp', '-o',
                             temp_outfile.name])
 
             with open('datafiles/test_script.txt', 'r') as target_outfile:


### PR DESCRIPTION
Also added a test for the `markdown-pp` command and fixed some whitespace that were driving the linter crazy.