### PR TITLE
Fix regex for INCLUDECODE

### DIFF
--- a/MarkdownPP/Modules/IncludeCode.py
+++ b/MarkdownPP/Modules/IncludeCode.py
@@ -22,7 +22,7 @@ class IncludeCode(Include):
 
     includere = re.compile(r"^!INCLUDECODE\s+(?:\"([^\"]+)\"|'([^']+)')"
                            r"(?:\s*\(\s*(.*)\s*\)\s*)?"
-                           r"\s*(?:,\s*(\d|(\d?:\d?)))?\s*$")
+                           r"\s*(?:,\s*(\d+|(\d*:\d*)))?\s*$")
 
     # include code should happen after includes, but before everything else
     priority = 0.1

--- a/test/datafiles/test_include_code_2.py
+++ b/test/datafiles/test_include_code_2.py
@@ -1,0 +1,12 @@
+def main():
+    print "Hello World"
+
+
+
+
+
+
+if __name__ == '__main__':
+    main()
+
+# Nothing to see here

--- a/test/test.py
+++ b/test/test.py
@@ -195,6 +195,29 @@ bar"""
         output.seek(0)
         self.assertEqual(output.read(), result)
 
+    def test_include_code_lines(self):
+        input = StringIO('foo\n!INCLUDECODE "datafiles/test_include_code_2.py" (python), 1:10\nbar')
+        result = """foo
+```python
+def main():
+    print "Hello World"
+
+
+
+
+
+
+if __name__ == '__main__':
+    main()
+
+```
+bar"""
+        output = StringIO()
+        MarkdownPP(input=input, modules=['includecode'], output=output)
+
+        output.seek(0)
+        self.assertEqual(output.read(), result)
+
     def test_include_code_single_line(self):
         input = StringIO('foo\n!INCLUDECODE "datafiles/test_include_code.py",1\nbar')
         result = """foo


### PR DESCRIPTION
As the regex was written previously, the line range for `INCLUDECODE` could only include a single numerical digit. As a result ranges like `1:10` would not parse.

This commit is intended to address that issue.