### PR TITLE
Fix a missed shift in INCLUDE command

### DIFF
--- a/MarkdownPP/Modules/Include.py
+++ b/MarkdownPP/Modules/Include.py
@@ -68,6 +68,8 @@ class Include(Module):
                 if match:
                     dirname = path.dirname(filename)
                     data[linenum:linenum+1] = self.include(match, dirname)
+                    # Update line so that we won't miss a shift if heading is on the 1st line
+                    line = data[linenum]
 
                 if shift:
 

--- a/MarkdownPP/Modules/Include.py
+++ b/MarkdownPP/Modules/Include.py
@@ -68,7 +68,8 @@ class Include(Module):
                 if match:
                     dirname = path.dirname(filename)
                     data[linenum:linenum+1] = self.include(match, dirname)
-                    # Update line so that we won't miss a shift if heading is on the 1st line
+                    # Update line so that we won't miss a shift if
+                    # heading is on the 1st line.
                     line = data[linenum]
 
                 if shift:


### PR DESCRIPTION
This fixes an issue where a shift is not performed on a heading on the first
line of a recursively INCLUDEd file.

**Example:**

FileA.mdpp:
```
# FileA-1
# FileA-2
!INCLUDE "FileB.mdpp",1
```

FileB.mdpp
```
# FileB-1
# FileB-2
!INCLUDE "FileC.mdpp",1
```

FileC.mdpp
```
# FileC-1
# FileC-2
```

Before this patch `markdown-pp FileA.mdpp` produces:
```
# FileA-1
# FileA-2

## FileB-1
## FileB-2

## FileC-1
### FileC-2
```
After this patch:
```
# FileA-1
# FileA-2

## FileB-1
## FileB-2

### FileC-1
### FileC-2
```