### PR TITLE
Changed regular expressions to allow spaces after code block delimiter

### DIFF
--- a/MarkdownPP/Modules/TableOfContents.py
+++ b/MarkdownPP/Modules/TableOfContents.py
@@ -13,7 +13,7 @@ from MarkdownPP.Transform import Transform
 tocre = re.compile("^!TOC(\s+[1-6])?\s*$")
 atxre = re.compile("^(#+)\s*(.+)$")
 setextre = re.compile("^(=+|-+)\s*$")
-fencedcodere = re.compile("^```\w*$")
+fencedcodere = re.compile("^```[ \w]*$")
 linkre = re.compile("(\[(.*?)\][\(\[].*?[\)\]])")
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -91,6 +91,33 @@ class MarkdownPPTests(unittest.TestCase):
         self.assertEqual([l.strip() for l in output.readlines()],
                          [l.strip() for l in result.split('\n')])
 
+    def test_toc_with_code_block(self):
+        input = StringIO(
+            '!TOC\n'
+            '# Header 1\n'
+            '```\n'
+            'code block\n'
+            '``` \n'
+            '# Header 2\n')
+
+        result = """1\.  [Header 1](#header1)
+        2\.  [Header 2](#header2)
+        <a name="header1"></a>
+
+        # 1\. Header 1
+        ```
+        code block
+        ```
+        <a name="header2"></a>
+        
+        # 2\. Header 2"""
+
+        output = StringIO()
+        MarkdownPP(input=input, modules=['tableofcontents'], output=output)
+        output.seek(0)
+        self.assertEqual([l.strip() for l in output.readlines()],
+                         [l.strip() for l in result.split('\n')])
+
     def test_reference(self):
         input = StringIO('\n!REF\n\n[github]: http://github.com "GitHub"')
         result = ('\n*\t[GitHub][github]\n\n[github]: '


### PR DESCRIPTION
Changed the regular expression in the TOC module to allow the code block delimiters to have spaces after them.

Closes #57

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jreese/markdown-pp/58)
<!-- Reviewable:end -->
