### PR TITLE
Added check for blank line underlines

### DIFF
--- a/MarkdownPP/Modules/TableOfContents.py
+++ b/MarkdownPP/Modules/TableOfContents.py
@@ -79,7 +79,7 @@ class TableOfContents(Module):
 
             # underlined headers
             match = setextre.search(line)
-            if match and not infencedcodeblock:
+            if match and not infencedcodeblock and lastline.strip():
                 depth = 1 if match.group(1)[0] == "=" else 2
                 title = lastline.strip()
                 headers[linenum-1] = (depth, title)


### PR DESCRIPTION
This should fix #54 by adding a check that the last line (after stripping white-space) was non-empty. Doing so should preserve dashes meant to indicate horizontal rules.