### PR TITLE
Don't demote empty underlines in included files

### DIFF
--- a/MarkdownPP/Modules/Include.py
+++ b/MarkdownPP/Modules/Include.py
@@ -76,9 +76,11 @@ class Include(Module):
                         to_del = []
                         for _ in range(shift):
                             # Skip underlines with empty above text
-                            # or underlines that are the first of an included file
-                            priortext = re.sub(self.formatre, '', data[linenum - 1].strip())
-                            isunderlined = priortext and linenum > includednum
+                            # or underlines that are the first line of an
+                            # included file
+                            prevtxt = re.sub(self.formatre, '',
+                                             data[linenum - 1]).strip()
+                            isunderlined = prevtxt and linenum > includednum
                             if data[linenum][0] == '#':
                                 data[linenum] = "#" + data[linenum]
                             elif data[linenum][0] == '=' and isunderlined:


### PR DESCRIPTION
This attempts to fix #65.

It does so by ensuring that, before demoting a underlined header to the next smallest subheader, that the line above it contains some text.

It adds two checks:
1. It checks that the current line is not the first of an included file
2. It checks that the line above the underline has some characters that are neither whitespace nor a non-escaped formatting character  

If these conditions pass then the underlined header is demoted.