### PR TITLE
Forcing the encoding from the Processor down to the modules

### DIFF
--- a/MarkdownPP/MarkdownPP.py
+++ b/MarkdownPP/MarkdownPP.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 from MarkdownPP import Modules
 from .Processor import Processor
-
+import sys
 
 class MarkdownPP:
     """
@@ -16,12 +16,15 @@ class MarkdownPP:
     Automatically executes the preprocessor with the requested modules.
     """
 
-    def __init__(self, input=None, output=None, modules=None):
-        pp = Processor()
+    def __init__(self, input=None, output=None, modules=None, encoding=None):
+        if encoding == None:
+            encoding = sys.getdefaultencoding()
+        pp = Processor(encoding)
 
         for name in [m.lower() for m in modules]:
             if name in Modules.modules:
                 module = Modules.modules[name]()
+                module.encoding = encoding
                 pp.register(module)
 
         pp.input(input)

--- a/MarkdownPP/Module.py
+++ b/MarkdownPP/Module.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
+import sys
 
 
 class Module:
@@ -18,6 +19,9 @@ class Module:
     and 5 being "normal".
     """
 
+    def __init__(self):
+        self.encoding = sys.getdefaultencoding()
+    
     def transform(self, data):
         """
         This method should generate a list of Transform objects for each

--- a/MarkdownPP/Modules/Include.py
+++ b/MarkdownPP/Modules/Include.py
@@ -52,7 +52,7 @@ class Include(Module):
 
     def include_file(self, filename, pwd="", shift=0):
         try:
-            f = open(filename, "r")
+            f = open(filename, "r", encoding = self.encoding)
             data = f.readlines()
             f.close()
 

--- a/MarkdownPP/Processor.py
+++ b/MarkdownPP/Processor.py
@@ -26,6 +26,9 @@ class Processor:
     transforms = {}
     modules = []
 
+    def __init__(self,encoding):
+        self.encoding = encoding
+    
     def register(self, module):
         """
         This method registers an individual module to be called when processing


### PR DESCRIPTION
On windows there is still the issue of the wrong encoding if the sources use some unicode characters.
With this I exposed the `encoding` parameter to the `MarkdownPP` class and now I can call it with:

`MarkdownPP(input=infile, modules=['include', 'toc'], output=outfile, encoding="UTF8")`

If no encoding is provided it's defaulted to `sys.getdefaultencoding()`

It was a quick fix I needed for one of my project, I'm open to any suggestion for writing it better.