### PR TITLE
Fixing flake8 and makefile targets

### DIFF
--- a/MarkdownPP/MarkdownPP.py
+++ b/MarkdownPP/MarkdownPP.py
@@ -9,6 +9,7 @@ from MarkdownPP import Modules
 from .Processor import Processor
 import sys
 
+
 class MarkdownPP:
     """
     Simplified front-end interface for the Processor and Module systems.
@@ -17,7 +18,7 @@ class MarkdownPP:
     """
 
     def __init__(self, input=None, output=None, modules=None, encoding=None):
-        if encoding == None:
+        if encoding is None:
             encoding = sys.getdefaultencoding()
         pp = Processor(encoding)
 

--- a/MarkdownPP/Module.py
+++ b/MarkdownPP/Module.py
@@ -21,7 +21,7 @@ class Module:
 
     def __init__(self):
         self.encoding = sys.getdefaultencoding()
-    
+
     def transform(self, data):
         """
         This method should generate a list of Transform objects for each

--- a/MarkdownPP/Modules/Include.py
+++ b/MarkdownPP/Modules/Include.py
@@ -52,7 +52,7 @@ class Include(Module):
 
     def include_file(self, filename, pwd="", shift=0):
         try:
-            f = open(filename, "r", encoding = self.encoding)
+            f = open(filename, "r", encoding=self.encoding)
             data = f.readlines()
             f.close()
 

--- a/MarkdownPP/Processor.py
+++ b/MarkdownPP/Processor.py
@@ -12,6 +12,7 @@ if sys.version_info[0] != 2:
 
 
 class Processor:
+
     """
     Framework for allowing modules to modify the input data as a set of
     transforms. Once the original input data is loaded, the preprocessor
@@ -26,9 +27,9 @@ class Processor:
     transforms = {}
     modules = []
 
-    def __init__(self,encoding):
+    def __init__(self, encoding):
         self.encoding = encoding
-    
+
     def register(self, module):
         """
         This method registers an individual module to be called when processing

--- a/makefile
+++ b/makefile
@@ -1,16 +1,18 @@
+PY=python3
+
 .PHONY: build dev upload lint test clean
 
 readme.md: readme.mdpp
 	markdown-pp readme.mdpp -o readme.md
 
 build: readme.md
-	python setup.py build
+	$(PY) setup.py build
 
 dev:
-	python setup.py develop
+	$(PY) setup.py develop
 
 upload: readme.md
-	python setup.py sdist upload
+	$(PY) setup.py sdist upload
 
 lint:
 	flake8 --show-source MarkdownPP
@@ -18,7 +20,7 @@ lint:
 test: lint
 	markdown-pp readme.mdpp -o readme.test && diff -u readme.md readme.test
 	rm -f readme.test
-	cd test/ && python test.py
+	cd test/ && $(PY) test.py
 
 clean:
 	rm -rf build dist README MANIFEST MarkdownPP.egg-info


### PR DESCRIPTION
Hello,

I could not run `make test` out of the box on my machine - flake8 complained about a number of things, then I ran into ImportError issues.

It turns out that `python` was defaulting to `python2` on my machine, and the provided Python scripts do not work with Python2.
They do work with Python3 though, so I changed `python` to `python3` in the makefile.