### PR TITLE
Executing a command and retrieving its result with !(EXEC cmd) syntax

### DIFF
--- a/MarkdownPP/Modules/Exec.py
+++ b/MarkdownPP/Modules/Exec.py
@@ -13,7 +13,7 @@ from MarkdownPP.Transform import Transform
 
 
 def trim_last_newline(s: str) -> str:
-    if s[-1] == '\n':
+    if len(s) > 0 and s[-1] == '\n':
         return s[:-1]
     else:
         return s

--- a/MarkdownPP/Modules/Exec.py
+++ b/MarkdownPP/Modules/Exec.py
@@ -83,7 +83,6 @@ class Exec(Module):
             if execcmd is not None:
                 break
         assert (execcmd is not None)
-        print("About to execute:", execcmd)
         charbefore = match.group(1)
         subp = subprocess.run(execcmd, shell=True, stdout=subprocess.PIPE)
         result = str(subp.stdout, "utf-8")

--- a/MarkdownPP/Modules/Exec.py
+++ b/MarkdownPP/Modules/Exec.py
@@ -1,0 +1,49 @@
+# Author: Cyril Six (sixcy), 2021
+# MIT License
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import re
+import subprocess
+
+from MarkdownPP.Module import Module
+from MarkdownPP.Transform import Transform
+
+
+def trim_last_newline(s: str) -> str:
+    if s[-1] == '\n':
+        return s[:-1]
+    else:
+        return s
+
+
+class Exec(Module):
+    """
+    Module for replacing !(EXEC "command") by the result of command
+    For example: !(EXEC date)
+    """
+
+    execre = re.compile(r'(^|[^\\])!\(EXEC ([^\)]*)\)')
+
+    def transform(self, data):
+        transforms = []
+        for (n, line) in enumerate(data):
+            matches = self.execre.finditer(line)
+            content = line
+            for match in matches:
+                content = self.do_exec(match, content)
+            transform = Transform(linenum=n, oper="swap", data=content)
+            transforms.append(transform)
+        return transforms
+
+    def do_exec(self, match, line):
+        execcmd = match.group(2)
+        charbefore = match.group(1)
+        subp = subprocess.run(execcmd.split(' '), stdout=subprocess.PIPE)
+        result = str(subp.stdout, "utf-8")
+        result = charbefore + trim_last_newline(result)
+
+        replaced = self.execre.sub(result, line, count=1)
+        return replaced

--- a/MarkdownPP/Processor.py
+++ b/MarkdownPP/Processor.py
@@ -28,7 +28,10 @@ class Processor:
 
     def __init__(self,encoding):
         self.encoding = encoding
-    
+        self.modules = []
+        self.data = []
+        self.transforms = {}
+
     def register(self, module):
         """
         This method registers an individual module to be called when processing

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ and process that document when viewing the repository.
 2.5\.  [Reference](#reference)  
 2.6\.  [LaTeX Rendering](#latexrendering)  
 2.7\.  [YouTube Embeds](#youtubeembeds)  
+2.8\.  [Execute a command](#executeacommand)  
 3\.  [Examples](#examples)  
 4\.  [Support](#support)  
 5\.  [References](#references)  
@@ -266,6 +267,30 @@ becomes
 
 [![Link to Youtube video](images/youtube/7aEYoP5-duY.png)](http://www.youtube.com/watch?v=7aEYoP5-duY)
 
+<a name="executeacommand"></a>
+
+### 2.8\. Execute a command
+
+With `!(EXEC cmd)` (or, if you prefer, `![EXEC cmd]`, or `!{EXEC cmd}`), it
+is possible to execute a command and insert the standard output result directly.
+
+For example:
+    !(EXEC echo "This is a test")
+
+Becomes:
+    This is a test
+
+To escape it, add a `\` to the command:
+    \!{EXEC "Will not be executed"}
+
+Make sure to not include any closing parenthesis, bracket or brace (depending on
+which delimiters you use) in the expression inside `!(EXEC ...)`
+
+This example will not work, and will produce a wrong output:
+    !(EXEC bash -c "(echo -n This is && echo a test)")
+
+Instead, use different delimiters:
+    !{EXEC bash -c "(echo -n This is && echo a test)"}
 
 <a name="examples"></a>
 

--- a/readme.mdpp
+++ b/readme.mdpp
@@ -237,6 +237,28 @@ becomes
 
 !VIDEO "http://www.youtube.com/embed/7aEYoP5-duY"
 
+### Execute a command
+
+With `\!(EXEC cmd)` (or, if you prefer, `\![EXEC cmd]`, or `\!{EXEC cmd}`), it
+is possible to execute a command and insert the standard output result directly.
+
+For example:
+    \!(EXEC echo "This is a test")
+
+Becomes:
+    !(EXEC echo "This is a test")
+
+To escape it, add a `\` to the command:
+    \\!{EXEC "Will not be executed"}
+
+Make sure to not include any closing parenthesis, bracket or brace (depending on
+which delimiters you use) in the expression inside `\!(EXEC ...)`
+
+This example will not work, and will produce a wrong output:
+    \!(EXEC bash -c "(echo -n This is && echo a test)")
+
+Instead, use different delimiters:
+    \!{EXEC bash -c "(echo -n This is && echo a test)"}
 
 Examples
 --------

--- a/test/test.py
+++ b/test/test.py
@@ -400,7 +400,7 @@ This should not be expanded: \!(EXEC echo nope)
 Testing toto titi
 tralala zut
 Possibility to use other delimiters: yesno
-This should not be expanded: \!(EXEC echo nope)
+This should not be expanded: !(EXEC echo nope)
 """
         output = StringIO()
         MarkdownPP(input=input, modules=['exec'], output=output)

--- a/test/test.py
+++ b/test/test.py
@@ -392,12 +392,14 @@ bar"""
         input = StringIO("""
 Testing !(EXEC echo toto) !(EXEC echo "titi")
 !(EXEC echo tralala) zut
+Possibility to use other delimiters: !{EXEC bash -c "(echo -n yes && echo no)"}
 This should not be expanded: \!(EXEC echo nope)
 """)
 
         result = """
-Testing toto "titi"
+Testing toto titi
 tralala zut
+Possibility to use other delimiters: yesno
 This should not be expanded: \!(EXEC echo nope)
 """
         output = StringIO()

--- a/test/test.py
+++ b/test/test.py
@@ -388,6 +388,22 @@ bar"""
         output.seek(0)
         self.assertEqual(output.read(), result)
 
+    def test_exec(self):
+        input = StringIO("""
+Testing !(EXEC echo toto) !(EXEC echo "titi")
+!(EXEC echo tralala) zut
+This should not be expanded: \!(EXEC echo nope)
+""")
+
+        result = """
+Testing toto "titi"
+tralala zut
+This should not be expanded: \!(EXEC echo nope)
+"""
+        output = StringIO()
+        MarkdownPP(input=input, modules=['exec'], output=output)
+        output.seek(0)
+        self.assertEqual(output.read(), result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello,

For my personal needs I implemented a new feature: `!(EXEC cmd)` to execute a command (with shell) and replace the syntax by its result.

This can be useful for automating the generation of a Markdown file, for instance inserting the current date (or, say, a version number):

`Project version: !{EXEC bash -c "./get_version.sh"}`
`Date of today: !(EXEC date)`

It is also possible to escape it; that's how the `readme.mdpp` is able to process correctly
`\!(EXEC This will not execute)`

If there are parenthesis/braces/brackets in the EXEC command, right now it will pose issues because I implemented it using a simple regexp (one would require a grammar to take care of matching parenthesis).

The workaround is to use different delimiters ; there are three available, parenthesis, brackets and braces
`\![EXEC echo "A command with different delimitors"]`

By using the PR https://github.com/jreese/markdown-pp/pull/79 I was able to pass all tests, except one (`exec_file`) which required to correct a minor bug (see commit https://github.com/jreese/markdown-pp/pull/80/commits/23c23f1cd1c3a44ae9f9143abebd8ba61bdebd62)

I'm open to any change